### PR TITLE
fixing checksum by reading binary

### DIFF
--- a/smugline.py
+++ b/smugline.py
@@ -98,7 +98,7 @@ class SmugLine(object):
 
     def _file_md5(self, filename, block_size=2**20):
         md5 = hashlib.md5()
-        f = open(filename)
+        f = open(filename, 'rb')
         while True:
             data = f.read(block_size)
             if not data:


### PR DESCRIPTION
# fixing checksum by reading binary
## test

this command return an error before this patch

```
python3 smugline.py upload åäö --from=/c/file/txt/program/smugline/test --api-key='' --email='' --password=''

  File "smugline.py", line 103, in _file_md5
    data = f.read(block_size)
  File "/usr/lib/python3.2/codecs.py", line 300, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```
