### PR TITLE
removing unused requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 argparse==1.2.1
 smugpy==0.3.1
-wsgiref==0.1.2
 docopt==0.6.1


### PR DESCRIPTION
# removing unused requirement
## do we use wsgiref?

where in smugline.py is wsgiref used?

how do we avoid using wsgiref for python >= 3.2?
## smugline still works after removing  wsgiref

i cant uninstall it

```
$ pip3.2 uninstall -y wsgiref
Can't uninstall 'wsgiref'. No files were found to uninstall.

$ pip uninstall -y wsgiref
Can't uninstall 'wsgiref'. No files were found to uninstall.
```

but i can remove it manually

```
rm /usr/lib/python2.7/wsgiref.egg-info; rm -rf /usr/lib/python2.7/wsgiref
rm /usr/lib/python3.2/wsgiref.egg-info; rm -rf /usr/lib/python3.2/wsgiref
```

verifying that it's gone

```
pip freeze
pip3.2 freeze
```

and smugline still works after that

```
$ pylint --errors-only --additional-builtins=raw_input smugline.py; echo $?
No config file found, using default configuration
0

python3 smugline.py upload åäö --from=/c/file/txt/program/smugline/test --api-key='' --email='' --password=''
skipping /c/file/txt/program/smugline/test/exotic_027.jpg (duplicate)
skipping /c/file/txt/program/smugline/test/McLaren_F1.jpg (duplicate)
```
## wsgiref doesn't work with python3

> part of the build fails

it's wsgiref-0.1.2.zip's fault according to the travis output

```
Downloading wsgiref-0.1.2.zip

File "/home/travis/virtualenv/python3.3/build/wsgiref/setup.py", line 5, in <module>

File "./ez_setup/__init__.py", line 170

print "Setuptools version",version,"or greater has been installed."
```

searching for the code https://www.google.com/search?q=wsgiref+print+%22Setuptools+version%22%2Cversion%2C%22or+greater+has+been+installed.%22 return the whole file http://sourcecodebrowser.com/python-wsgiref/0.1.2/ez__setup_2____init_____8py_source.html that contain a python3 incompatible print

according to https://pypi.python.org/pypi/wsgiref it's for python < 3.2

> This is a standalone release of the wsgiref library, that provides validation support for WSGI 1.0.1 (PEP 3333) for Python versions < 3.2
