### PR TITLE
Fix Issue when the image is already downloaded

### DIFF
--- a/smugline.py
+++ b/smugline.py
@@ -107,11 +107,12 @@ class SmugLine(object):
         return local_filename
 
     def set_file_timestamp(self, filename, image):
-        # apply the image date
-        image_info = self.get_image_info(image)
-        timestamp = time.strptime(image_info['Image']['Date'], '%Y-%m-%d %H:%M:%S')
-        t = time.mktime(timestamp)
-        os.utime(filename, (t, t))
+        if filename is not None:
+          # apply the image date
+          image_info = self.get_image_info(image)
+          timestamp = time.strptime(image_info['Image']['Date'], '%Y-%m-%d %H:%M:%S')
+          t = time.mktime(timestamp)
+          os.utime(filename, (t, t))
 
     def upload_json(self, source_folder, json_file):
         images = json.load(open(json_file))


### PR DESCRIPTION
If the image already exists the `self.download_file`  returns `None` value, which would cause the  `set_file_timestamp` to throw an exception.

This simply adds a check in `set_file_timestamp` to make sure the filename is not `None` before doing anything.