### PR TITLE
Handle API errors with more grace

### DIFF
--- a/smugline.py
+++ b/smugline.py
@@ -101,7 +101,7 @@ class SmugLine(object):
                 self.smugmug.images_upload(AlbumID=album['id'], **image)
                 return
             except HTTPError:
-                print("RETRY ", image)
+                print("retry ", image)
                 retries -= 1
 
     # source: http://stackoverflow.com/a/16696317/305019

--- a/smugline.py
+++ b/smugline.py
@@ -180,7 +180,7 @@ class SmugLine(object):
 
     def _get_md5_hashes_for_album(self, album):
         remote_images = self._get_remote_images(album, 'MD5Sum')
-        md5_sums = [x['MD5Sum'] for x in remote_images['Album']['Images'] if 'MD5Sum' in x]
+        md5_sums = [x['MD5Sum'] for x in remote_images['Album']['Images']]
         self.md5_sums[album['id']] = md5_sums
         return md5_sums
 


### PR DESCRIPTION
The API will occasonally not return an MD5 for an image skip those in
the list of MD5 we consider. Also add retry logic to the uploader to
handle transient errors.