### PR TITLE
Skip images with missing OriginalURL

### DIFF
--- a/smugline.py
+++ b/smugline.py
@@ -168,6 +168,9 @@ class SmugLine(object):
     def _download(self, images, dest_folder):
         for img in images:
             print('downloading {0} -> {1}'.format(img['FileName'], dest_folder))
+            if 'OriginalURL' not in img:
+                print('{0} has no OriginalURL...skipping'.format(img['FileName']))
+                continue
             filename = self.download_file(img['OriginalURL'], dest_folder, img['FileName'])
             self.set_file_timestamp(filename, img)
 

--- a/smugline.py
+++ b/smugline.py
@@ -169,7 +169,7 @@ class SmugLine(object):
         for img in images:
             print('downloading {0} -> {1}'.format(img['FileName'], dest_folder))
             if 'OriginalURL' not in img:
-                print('{0} has no OriginalURL...skipping'.format(img['FileName']))
+                print('no permission to download {0}...skipping'.format(img['FileName']))
                 continue
             filename = self.download_file(img['OriginalURL'], dest_folder, img['FileName'])
             self.set_file_timestamp(filename, img)


### PR DESCRIPTION
Sometimes the OriginalURL of the image is not returned, which results
in a KeyError. I think it is better to report the problem and go on than to
to fail.

For me the problem occurs for some (but not all) images in smart albums.
These images in their original album do have a the OriginalURL attribute.
I'm not the only one with this problem; see for example:
https://dgrin.com/discussion/259053/smugmug-image-download-through-api-originalurl-working-for-some-and-not-for-some