### PR TITLE
Add download_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You only need the `Key` (no need for the `Secret`).
 * listing albums on your smugmug account
 * uploading from a folder (recursively) to an album on smugmug
 * downloading from an album on smugmug to a local folder
+* downloading all albums on smugmug to a local folder
 * existing images will be uploaded only once (skipping duplicates)
 * uploading images, videos or both (default: images)
 * clearing duplicate images or video from an album
@@ -41,6 +42,11 @@ Usage:
                                     [--media=(videos | images | all)]
                                     [--email=email_address]
                                     [--password=password]
+  smugline.py download_all --api-key=<apy_key>
+                           [--to=folder_name]
+                           [--media=(videos | images | all)]
+                           [--email=email_address]
+                           [--password=password]
   smugline.py process <json_file> --api-key=<apy_key>
                                   [--from=folder_name]
                                   [--email=email_address]
@@ -60,6 +66,7 @@ Usage:
 Arguments:
   upload            uploads files to a smugmug album
   download          downloads an entire album into a folder
+  download_all      downloads all albums into a folder structure
   process           processes a json file with upload directives
   list              list album names on smugmug
   create            create a new album
@@ -135,6 +142,16 @@ downloading IMG_123.jpg -> /tmp/
 downloading IMG_124.jpg -> /tmp/
 ...
 downloading IMG_999.jpg -> /tmp/
+```
+
+download all albums to /tmp/ folder
+
+```shell
+$ ./smugline.py download_all --to=/tmp/ --api-key=... --email=your@email.com --password=yourpassword
+downloading IMG_123.jpg -> /tmp/album_1
+downloading IMG_124.jpg -> /tmp/album_1
+...
+downloading IMG_999.jpg -> /tmp/album_2
 ```
 
 creating a new album (will create under 'Other' category)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Options:
   --privacy=(unlisted | public)
                           album privacy settings [default: unlisted]
   --email=email_address   email address of your smugmug account
-  --passwod=password      smugmug password
+  --password=password     smugmug password
 ```
 
 list albums

--- a/smugline.py
+++ b/smugline.py
@@ -168,6 +168,9 @@ class SmugLine(object):
     def _download(self, images, dest_folder):
         for img in images:
             print('downloading {0} -> {1}'.format(img['FileName'], dest_folder))
+            if 'OriginalURL' not in img:
+                print('{0} has no OriginalURL...skipping'.format(img['FileName']))
+                continue
             filename = self.download_file(img['OriginalURL'], dest_folder, img['FileName'])
             self.set_file_timestamp(filename, img)
 

--- a/smugline.py
+++ b/smugline.py
@@ -169,7 +169,7 @@ class SmugLine(object):
         for img in images:
             print('downloading {0} -> {1}'.format(img['FileName'], dest_folder))
             if 'OriginalURL' not in img:
-                print('{0} has no OriginalURL...skipping'.format(img['FileName']))
+                print('no permission to download {0}...skipping'.format(img['FileName']))
                 continue
             filename = self.download_file(img['OriginalURL'], dest_folder, img['FileName'])
             self.set_file_timestamp(filename, img)

--- a/smugline.py
+++ b/smugline.py
@@ -50,7 +50,7 @@ Options:
   --privacy=(unlisted | public)
                           album privacy settings [default: unlisted]
   --email=email_address   email address of your smugmug account
-  --passwod=password      smugmug password
+  --password=password     smugmug password
 
 """
 

--- a/smugline.py
+++ b/smugline.py
@@ -171,7 +171,8 @@ class SmugLine(object):
                           album.get('SubCategory', {}).get('Name'),
                           album.get('Title')]
             dest_subfolder = os.path.join(dest_folder, *[path for path in album_path if path])
-            os.makedirs(dest_subfolder, exist_ok=True)
+            if not os.path.exists(dest_subfolder):
+                os.makedirs(dest_subfolder)
             images = self._get_images_for_album(album, file_filter=file_filter)
             self._download(images, dest_subfolder)
 


### PR DESCRIPTION
Like the name says download_all will download all albums of a user
into a file tree. Folders in which the albums reside on SmugMug
will be created locally. 

Folders are only recognized (and hence created) up to a depth of two,
as the API version we're using was made before folders over a depth of
two were allowed on SmugMug. Albums deeper than two levels in folders
will still be created, but folders in between the first and the last levels will
be missing. Also, albums in the root of a user are shown as if they are in 
the "Homepage/" folder. Nevertheless this makes a complete backup of
all content.

Also, I took the liberty of fixing a typo.